### PR TITLE
CircleCI tests based on GSD CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,325 @@
+version: 2.1
+
+executors:
+  glotzerlab:
+    parameters:
+      image:
+        type: string
+      python-version:
+        type: string
+    docker:
+      - image: glotzerlab/ci:2018.10-<< parameters.image >>
+    environment:
+      PYTHONPATH: /home/ci/project/build
+      PYTHON: "/usr/bin/python<< parameters.python-version >>"
+      PYTEST: "/usr/bin/python<< parameters.python-version >> -m pytest"
+    working_directory: /home/ci/project
+
+commands:
+  build:
+    parameters:
+      cc:
+        type: string
+      cxx:
+        type: string
+      cmake:
+        type: string
+    steps:
+      - checkout:
+          path: code
+      - run:
+          name: Configure CMake build
+          command: export CC=<< parameters.cc >> CXX=<< parameters.cxx >> && mkdir build && cd build && << parameters.cmake >> ../code -DPYTHON_EXECUTABLE=${PYTHON} -DCYTHON_EXECUTABLE=`which cython3` -GNinja
+      - run:
+          name: Build with CMake
+          command: cd build && ninja
+      - run:
+          name: Build Python module
+          command: cd code && ${PYTHON} setup.py install --user --cython
+
+  test:
+    steps:
+      - run:
+          name: Test CMake build
+          command: build/test/test_records && build/test/test_gtar
+      - run:
+          name: Test Python module
+          command: mkdir test-results && cd code/test && ${PYTEST} --junit-xml=/home/ci/project/test-results/test.xml
+      - store_artifacts:
+          path: test-results
+          destination: test-results
+      - store_test_results:
+          path: test-results
+
+
+jobs:
+  build_and_test:
+    parameters:
+      image:
+        type: string
+      cc:
+        type: string
+      cxx:
+        type: string
+      python-version:
+        type: string
+      cmake:
+        default: /usr/bin/cmake
+        type: string
+    executor:
+      name: glotzerlab
+      image: << parameters.image >>
+      python-version: << parameters.python-version >>
+    steps:
+      - build:
+          cc: << parameters.cc >>
+          cxx: << parameters.cxx >>
+          cmake: << parameters.cmake >>
+      - test
+
+  pypi-linux-wheels:
+    parameters:
+      python:
+        type: string
+      upload-package:
+        type: boolean
+        default: false
+      run-tests:
+        type: boolean
+        default: true
+      build-sdist:
+        type: boolean
+        default: false
+    docker:
+      - image: quay.io/pypa/manylinux1_x86_64
+    environment:
+      PYBIN: "/opt/python/<< parameters.python >>/bin"
+    steps:
+      - run:
+          name: Install software
+          working_directory: /root/code
+          command: yum install -y openssh-clients
+      - run:
+          name: Checkout repository
+          command: |
+            cd /root
+            git clone https://github.com/glotzerlab/${CIRCLE_PROJECT_REPONAME} code
+            cd code
+            if [ -n "$CIRCLE_TAG" ]
+            then
+              git reset --hard "$CIRCLE_SHA1"
+              git checkout -q "$CIRCLE_TAG"
+            elif [ -n "$CIRCLE_BRANCH" ]
+            then
+              git reset --hard "$CIRCLE_SHA1"
+              git checkout -q -B "$CIRCLE_BRANCH"
+            fi
+      - run:
+          name: Build numpy
+          working_directory: /
+          command: |
+            "${PYBIN}/python" -m pip install cython --no-deps --ignore-installed -q --progress-bar=off
+            curl -sSLO https://github.com/numpy/numpy/archive/v1.9.3.tar.gz
+            tar -xzf v1.9.3.tar.gz
+            cd numpy-1.9.3
+            rm -f numpy/random/mtrand/mtrand.c
+            rm -f PKG-INFO
+            "${PYBIN}/python" -m pip install . --no-deps --ignore-installed -v --progress-bar=off -q
+      - run:
+          name: Compile gtar wheels
+          working_directory: /root/code
+          command: |
+            "${PYBIN}/python" -m pip wheel -w wheels/ . --no-deps --progress-bar=off --no-build-isolation --no-use-pep517
+      - run:
+          name: Audit wheels
+          working_directory: /root/code
+          command: |
+            for whl in wheels/gtar*.whl; do
+                auditwheel repair "$whl" -w dist/
+            done
+      - when:
+          condition: << parameters.run-tests >>
+          steps:
+            - run:
+                name: Test wheels (old numpy)
+                working_directory: /root/code
+                command: |
+                  "${PYBIN}/pip" install nose --progress-bar=off
+                  "${PYBIN}/pip" install gtar --no-index -f dist --progress-bar=off
+                  cd test && "${PYBIN}/nosetests"
+            - run:
+                name: Test wheels (latest numpy)
+                working_directory: /root/code
+                command: |
+                  "${PYBIN}/pip" install numpy --upgrade --progress-bar=off
+                  "${PYBIN}/pip" install gtar --no-index -f dist --progress-bar=off
+                  cd test && "${PYBIN}/nosetests"
+      - when:
+          condition: << parameters.build-sdist >>
+          steps:
+            - run:
+                name: Build sdist
+                working_directory: /root/code
+                command: |
+                  export PYBIN=/opt/python/cp37-cp37m/bin
+                  "${PYBIN}/python" setup.py sdist
+      - when:
+          condition: << parameters.upload-package >>
+          steps:
+            - run:
+                name: Upload
+                working_directory: /root/code
+                command: |
+                  export PYBIN=/opt/python/cp37-cp37m/bin
+                  "${PYBIN}/pip" install twine --progress-bar=off
+                  "${PYBIN}/twine" upload --username bdice --password ${PYPI_PASSWORD} dist/*
+      - unless:
+          condition: << parameters.upload-package >>
+          steps:
+            - run: echo "Branch build, skipping upload"
+      - store_artifacts:
+          path: /root/code/dist
+workflows:
+  test:
+    jobs:
+      - build_and_test:
+          name: gcc8-py36
+          image: ubuntu18.04
+          cc: gcc-8
+          cxx: g++-8
+          python-version: "3.6"
+
+      - build_and_test:
+          name: gcc7-py36
+          image: ubuntu18.04
+          cc: gcc-7
+          cxx: g++-7
+          python-version: "3.6"
+
+      - build_and_test:
+          name: gcc6-py36
+          image: ubuntu18.04
+          cc: gcc-6
+          cxx: g++-6
+          python-version: "3.6"
+
+      - build_and_test:
+          name: clang6-py36
+          image: ubuntu18.04
+          cc: clang-6.0
+          cxx: clang++-6.0
+          python-version: "3.6"
+
+      - build_and_test:
+          name: clang5-py36
+          image: ubuntu18.04
+          cc: clang-5.0
+          cxx: clang++-5.0
+          python-version: "3.6"
+
+      - build_and_test:
+          name: clang4-py36
+          image: ubuntu18.04
+          cc: clang-4.0
+          cxx: clang++-4.0
+          python-version: "3.6"
+
+      - build_and_test:
+          name: gcc5-py35
+          image: ubuntu16.04
+          cc: gcc-5
+          cxx: g++-5
+          python-version: "3.5"
+
+      - build_and_test:
+          name: clang38-py35
+          image: ubuntu16.04
+          cc: clang-3.8
+          cxx: clang++-3.8
+          python-version: "3.5"
+
+      - build_and_test:
+          name: gcc48-py35-cm28
+          image: ubuntu16.04
+          cc: gcc-4.8
+          cxx: g++-4.8
+          python-version: "3.5"
+          cmake: /opt/cmake-2.8.12/bin/cmake
+
+      - pypi-linux-wheels:
+          name: wheel-build-cp27m
+          python: cp27-cp27m
+          run-tests: false
+
+      - pypi-linux-wheels:
+          name: wheel-build-cp27mu
+          python: cp27-cp27mu
+          run-tests: false
+
+      - pypi-linux-wheels:
+          name: wheel-build-cp35m
+          python: cp35-cp35m
+
+      - pypi-linux-wheels:
+          name: wheel-build-cp36m
+          python: cp36-cp36m
+
+      - pypi-linux-wheels:
+          name: wheel-build-cp37m
+          python: cp37-cp37m
+          build-sdist: true
+
+  deploy:
+    jobs:
+      - pypi-linux-wheels:
+          name: wheel-upload-cp27m
+          python: cp27-cp27m
+          run-tests: false
+          upload-package: true
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+
+      - pypi-linux-wheels:
+          name: wheel-upload-cp27mu
+          python: cp27-cp27mu
+          run-tests: false
+          upload-package: true
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+
+      - pypi-linux-wheels:
+          name: wheel-upload-cp35m
+          python: cp35-cp35m
+          upload-package: true
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+
+      - pypi-linux-wheels:
+          name: wheel-upload-cp36m
+          python: cp36-cp36m
+          upload-package: true
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+
+      - pypi-linux-wheels:
+          name: wheel-upload-cp37m
+          python: cp37-cp37m
+          build-sdist: true
+          upload-package: true
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,13 +29,18 @@ commands:
           path: code
       - run:
           name: Configure CMake build
-          command: export CC=<< parameters.cc >> CXX=<< parameters.cxx >> && mkdir build && cd build && << parameters.cmake >> ../code -DPYTHON_EXECUTABLE=${PYTHON} -DCYTHON_EXECUTABLE=`which cython3` -GNinja
+          command: export CC=<< parameters.cc >> CXX=<< parameters.cxx >> && mkdir build && cd build && << parameters.cmake >> ../code -DPYTHON_EXECUTABLE=${PYTHON} -GNinja
       - run:
           name: Build with CMake
           command: cd build && ninja
       - run:
+          name: Install pip
+          command: |
+            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+            ${PYTHON} get-pip.py --user
+      - run:
           name: Build Python module
-          command: cd code && ${PYTHON} setup.py install --user --cython
+          command: export CC=<< parameters.cc >> CXX=<< parameters.cxx >> && ${PYTHON} -m pip install --user --no-build-isolation --no-use-pep517 ./code
 
   test:
     steps:
@@ -50,7 +55,6 @@ commands:
           destination: test-results
       - store_test_results:
           path: test-results
-
 
 jobs:
   build_and_test:
@@ -81,9 +85,6 @@ jobs:
     parameters:
       python:
         type: string
-      upload-package:
-        type: boolean
-        default: false
       run-tests:
         type: boolean
         default: true
@@ -163,22 +164,9 @@ jobs:
                 command: |
                   export PYBIN=/opt/python/cp37-cp37m/bin
                   "${PYBIN}/python" setup.py sdist
-      - when:
-          condition: << parameters.upload-package >>
-          steps:
-            - run:
-                name: Upload
-                working_directory: /root/code
-                command: |
-                  export PYBIN=/opt/python/cp37-cp37m/bin
-                  "${PYBIN}/pip" install twine --progress-bar=off
-                  "${PYBIN}/twine" upload --username bdice --password ${PYPI_PASSWORD} dist/*
-      - unless:
-          condition: << parameters.upload-package >>
-          steps:
-            - run: echo "Branch build, skipping upload"
       - store_artifacts:
           path: /root/code/dist
+
 workflows:
   test:
     jobs:
@@ -238,14 +226,6 @@ workflows:
           cxx: clang++-3.8
           python-version: "3.5"
 
-      - build_and_test:
-          name: gcc48-py35-cm28
-          image: ubuntu16.04
-          cc: gcc-4.8
-          cxx: g++-4.8
-          python-version: "3.5"
-          cmake: /opt/cmake-2.8.12/bin/cmake
-
       - pypi-linux-wheels:
           name: wheel-build-cp27m
           python: cp27-cp27m
@@ -272,10 +252,9 @@ workflows:
   deploy:
     jobs:
       - pypi-linux-wheels:
-          name: wheel-upload-cp27m
+          name: wheel-deploy-cp27m
           python: cp27-cp27m
           run-tests: false
-          upload-package: true
           filters:
             tags:
               only: /^v.*/
@@ -283,10 +262,9 @@ workflows:
               ignore: /.*/
 
       - pypi-linux-wheels:
-          name: wheel-upload-cp27mu
+          name: wheel-deploy-cp27mu
           python: cp27-cp27mu
           run-tests: false
-          upload-package: true
           filters:
             tags:
               only: /^v.*/
@@ -294,9 +272,8 @@ workflows:
               ignore: /.*/
 
       - pypi-linux-wheels:
-          name: wheel-upload-cp35m
+          name: wheel-deploy-cp35m
           python: cp35-cp35m
-          upload-package: true
           filters:
             tags:
               only: /^v.*/
@@ -304,9 +281,8 @@ workflows:
               ignore: /.*/
 
       - pypi-linux-wheels:
-          name: wheel-upload-cp36m
+          name: wheel-deploy-cp36m
           python: cp36-cp36m
-          upload-package: true
           filters:
             tags:
               only: /^v.*/
@@ -314,10 +290,9 @@ workflows:
               ignore: /.*/
 
       - pypi-linux-wheels:
-          name: wheel-upload-cp37m
+          name: wheel-deploy-cp37m
           python: cp37-cp37m
           build-sdist: true
-          upload-package: true
           filters:
             tags:
               only: /^v.*/

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@
 
 import os, subprocess, sys
 from distutils.command.build_ext import build_ext
-from setuptools import Extension, setup
+try:
+    from setuptools import Extension, setup
+except ImportError:
+    from distutils.core import Extension, setup
 import numpy
 
 long_description = """

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,7 @@
 
 import os, subprocess, sys
 from distutils.command.build_ext import build_ext
-try:
-    from setuptools import Extension, setup
-except ImportError:
-    from distutils.core import Extension, setup
+from setuptools import Extension, setup
 import numpy
 
 long_description = """


### PR DESCRIPTION
Adding continuous integration based on https://github.com/glotzerlab/gsd.

@klarh Please note that this pull request also adds automatic deployment to PyPI for tagged releases. If you don't want that, that is fine. I can't promise that the automated PyPI release of tags will work properly the first time, given my experience with automated releases, but I do think it's worth the time to get right (of course, if you already have an process you use and wish to keep maintaining the release process, that's fine with me). We could modify this CI script to support the PyPI test server (as is done with signac) if you'd like to test the upload process before making an official release with the automated tooling.