### PR TITLE
Use unique_ptr instead of auto_ptr.

### DIFF
--- a/src/GTAR.hpp
+++ b/src/GTAR.hpp
@@ -119,7 +119,7 @@ namespace gtar{
         /// Read a uniform binary property to the specified location,
         /// converting from little endian if necessary.
         template<typename T>
-        std::auto_ptr<T> readUniform(const std::string &path);
+        std::unique_ptr<T> readUniform(const std::string &path);
         /// Read a bytestring from the specified location
         SharedArray<char> readBytes(const std::string &path);
 
@@ -162,7 +162,7 @@ namespace gtar{
         void insertRecord(const std::string &path);
 
         /// The archive abstraction object we'll use
-        std::auto_ptr<Archive> m_archive;
+        std::unique_ptr<Archive> m_archive;
 
         /// Cached record objects
         std::map<Record, indexSet> m_records;
@@ -250,16 +250,16 @@ namespace gtar{
     }
 
     template<typename T>
-    std::auto_ptr<T> GTAR::readUniform(const std::string &path)
+    std::unique_ptr<T> GTAR::readUniform(const std::string &path)
     {
         SharedArray<char> bytes(m_archive->read(path));
 
         maybeSwapEndian<T>((T*) bytes.get(), bytes.size());
 
         if(bytes.size())
-            return std::auto_ptr<T>(new T(*(T*) bytes.get()));
+            return std::unique_ptr<T>(new T(*(T*) bytes.get()));
         else
-            return std::auto_ptr<T>();
+            return std::unique_ptr<T>();
     }
 
 }

--- a/src/ZipArchive.cpp
+++ b/src/ZipArchive.cpp
@@ -14,7 +14,7 @@ namespace GTAR_NAMESPACE_PARENT{
 
 namespace gtar{
 
-    using std::auto_ptr;
+    using std::unique_ptr;
     using std::runtime_error;
     using std::string;
     using std::stringstream;

--- a/src/ZipArchive.cpp
+++ b/src/ZipArchive.cpp
@@ -14,7 +14,6 @@ namespace GTAR_NAMESPACE_PARENT{
 
 namespace gtar{
 
-    using std::unique_ptr;
     using std::runtime_error;
     using std::string;
     using std::stringstream;

--- a/test/test_GTAR.cpp
+++ b/test/test_GTAR.cpp
@@ -19,7 +19,7 @@ void runTests(int &result, string suffix)
         arch.close();
 
         GTAR readArch("test" + suffix, Read);
-        unique_ptr<int> readUniform(readArch.readUniform<int>("test.i64.uni"));
+        SharedPtr<int> readUniform(readArch.readUniform<int>("test.i64.uni"));
 
         if(!readUniform.get())
         {

--- a/test/test_GTAR.cpp
+++ b/test/test_GTAR.cpp
@@ -19,7 +19,7 @@ void runTests(int &result, string suffix)
         arch.close();
 
         GTAR readArch("test" + suffix, Read);
-        auto_ptr<int> readUniform(readArch.readUniform<int>("test.i64.uni"));
+        unique_ptr<int> readUniform(readArch.readUniform<int>("test.i64.uni"));
 
         if(!readUniform.get())
         {


### PR DESCRIPTION
This PR aims to resolve #14. I am not extremely familiar with the implications of this change, though it appears to be the recommended approach for updating `auto_ptr`. Tests are passing but I would appreciate a critical look from reviewers.